### PR TITLE
Fix SSR title leakage on root /about /contact /projects

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -5,7 +5,7 @@
 	import { buildBreadcrumbSchema } from '$lib/seo.js';
 
 	$: description = $t('about.description');
-	$: title = `${$t('linkabout')} — Vincent Charlebois`;
+	const title = 'About — Vincent Charlebois';
 	const schema = buildBreadcrumbSchema([
 		{ name: 'Home', path: '/' },
 		{ name: 'About', path: '/about' }

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -4,7 +4,7 @@
 	import { buildBreadcrumbSchema } from '$lib/seo.js';
 
 	$: description = $t('contact.description');
-	$: title = `${$t('linkcontact')} — Vincent Charlebois`;
+	const title = 'Contact — Vincent Charlebois';
 	const schema = buildBreadcrumbSchema([
 		{ name: 'Home', path: '/' },
 		{ name: 'Contact', path: '/contact' }

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -4,7 +4,7 @@
 	import Markdown from '$components/Markdown.svelte';
 	import { buildBreadcrumbSchema } from '$lib/seo.js';
 	$: description = $t('projects.description');
-	$: title = `${$t('linkprojects')} — Vincent Charlebois`;
+	const title = 'Projects — Vincent Charlebois';
 	const schema = buildBreadcrumbSchema([
 		{ name: 'Home', path: '/' },
 		{ name: 'Projects', path: '/projects' }


### PR DESCRIPTION
## Summary
Replace reactive `$: title = \`${$t('link...')} — Vincent Charlebois\`` with hardcoded `const title` in the three root route pages. During SSR/prerendering, svelte-i18n may not be initialized so `$t()` returns the key or empty string, producing a broken duplicate `<title>` tag before hooks.server.js can override it. These are English-only fallback routes — no i18n needed for the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Page titles on the About, Contact, and Projects pages are now fixed to static English values instead of responding to language preference changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->